### PR TITLE
Avoid Redirection of API URL

### DIFF
--- a/lib/geo_ppp/fetcher.rb
+++ b/lib/geo_ppp/fetcher.rb
@@ -3,7 +3,8 @@ require 'json'
 
 class GeoPPPFetcher
   GEO_API_URL = 'https://freegeoip.app/json/'.freeze
-  PPP_API_URL = 'https://api.purchasing-power-parity.com/?target='.freeze
+	# https://api.purchasing-power-parity.com/?target=ID redirects to https://ppp-api.fly.dev/?target=ID and then results are returned
+  PPP_API_URL = 'https://ppp-api.fly.dev/?target='.freeze
 
   def self.fetch
 	 geo = fetch_geo


### PR DESCRIPTION
`PPP_API_URL` redirects to another url so I am using the redirect url directly to avoid redirection and fast response.